### PR TITLE
Added Processes for Securely Managing Apple and Google App Signing Certs and Keys

### DIFF
--- a/processes/BLL-Process-For-Securely-Managing-App-Store-Signing-Certificates.md
+++ b/processes/BLL-Process-For-Securely-Managing-App-Store-Signing-Certificates.md
@@ -1,0 +1,12 @@
+### Process for Securely Managing App Store Signing Certificates
+
+1. Generate a certificate signing request using Keychain Assistant
+2. Create the desired certificate using the CSR generated in Step 1
+3. Download and install the certificate locally
+4. Find the certificate in Keychain Assistant and export the private keys as a .p12 file
+5. Enter a secure password (min 18 chars, 1 uppercase, 1 special char) when prompted by Keychain Assistant
+6. Save the password you entered in Passbolt naming it: {BL-project-code}/{Project-name}/{Certificate Name} e.g: BL888/FooProject/DistributionCertificate
+7. Share the password you created in Passbolt with the project group
+8. Save the certificate (.cer) and private key (.p12) in Dropbox in the path /{Project Directory}/Certificates/Apple/
+9. (optional) If sharing with an external entity, use Signal App to send password, then delete message when counterparty confirms receiving the message 
+

--- a/processes/BLL-Process-For-Securely-Managing-Play-Store-Signing-Keystores.md
+++ b/processes/BLL-Process-For-Securely-Managing-Play-Store-Signing-Keystores.md
@@ -1,0 +1,15 @@
+### Process for Securely Managing Play Store Signing Keystore
+
+1. In Android Studio, select Build > **Generate Signed Bundle or APK**
+2. Select Android App Bundle > **Next**
+3. Under the Key store path field, select **Create New**
+4. In the *Key Store Path* field: enter a name for your keystore file with a .keystore extension 
+5. Fill out form fields making sure to note the *Key Store Password*, *Key Password*, and *Key Alias*. Use secure (min 18 chars, 1 uppercase, 1 special char), unique passwords for the *Key Store Password* and *Key Password*  
+6. Click **OK** to generate the keystore file 
+7. Save the *Key Store Password*  in Passbolt naming it: {BL-project-code}/{Project-name}/AndroidKeyStorePassword e.g: BL888/FooProject/AndroidKeyStorePassword
+8. Save the *Key Password*  in Passbolt naming it: {BL-project-code}/{Project-name}/AndroidKeyPassword e.g: BL888/FooProject/AndroidKeyPassword
+9. Save the *Key Alias*  in Passbolt naming it: {BL-project-code}/{Project-name}/AndroidKeyAlias e.g: BL888/FooProject/AndroidKeyAlias
+10. Share the *Key Store Password*, *Key Password*, and *Key Alias* you created in Passbolt with the project group
+11. Save the keystore file (.keystore) in Dropbox in the path /{Project Directory}/Keystores/Google/
+12. (optional) If sharing with an external entity, use Signal App to send passwords and alias, then delete message when counterparty confirms receiving the message
+

--- a/standards/BLL-Mobile-Standards.md
+++ b/standards/BLL-Mobile-Standards.md
@@ -37,6 +37,11 @@ Passwords, and any other secure login information, **must** be stored in the iOS
 Android code should be protected with proguard.
 - Ensure code obfuscation is turned on.
 
+##### App Signing
+
+- [Process For Securely Managing Play Store Signing Keystores](../processes/BLL-Process-For-Securely-Managing-Play-Store-Signing-Keystores.md)
+- [Process For Securely Managing App Store Store Signing Certificates](../processes/BLL-Process-For-Securely-Managing-App-Store-Signing-Certificates.md)
+
 ### 6. Handling User Sessions
 - When a user logs in to a web service and receives a OAuth access token, this access token **must** be stored within the platform keychain and not in UserDefaults.
 - Unless otherwise specified by the client, OAuth access tokens should be set with an expiry time of at least 1 month.


### PR DESCRIPTION
Also added links to the processes in BLL Mobile Standards doc