### PR TITLE
Regenerate the golden path

### DIFF
--- a/golden-path/ml-training.md
+++ b/golden-path/ml-training.md
@@ -25,7 +25,7 @@ the defaults we reach for, and how to choose when they do not settle it.
 - Image detection / computer vision: **YOLO** as the starting point.
 - Classical / tabular ML: **scikit-learn** and **XGBoost**.
 - Pretrained models: pull from **HuggingFace**.
-- Experiment tracking, pipelines, and model registry: **MLflow**.
+- Experiment tracking, pipelines, and model registry: **MLflow**, on a BlueLabel self-hosted instance.
 - Data labeling: **Label Studio** on a BlueLabel self-hosted instance.
 - Inference hosting: **Amazon SageMaker** (AWS) / **Azure ML** (Azure) — real-time endpoints.
 - Training compute: local or cloud GPU.


### PR DESCRIPTION
Rendered from `blueprint@662722d77e7869a978598e1c152019c4a89d2040` by the sync-guidelines workflow.

Everything under `golden-path/` is generated. Do not hand-edit it; change the pack and let this run again.

No pack invariants changed, so the guidelines catalog needs no edit. This is a golden-path-only update.
