### PR TITLE
Reconcile source control with the 2023 Git standards

### DIFF
--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -156,7 +156,7 @@ Applies to everyone who directs an agent, product and engineering alike.
 | AI-009 | Experiments are reproducible and tracked: versioned notebooks, prompts, and datasets. |
 | AI-010 | An experimentation workstream has an explicit hypothesis, success criteria, and decision gate defined before it starts. |
 | AI-011 | Every LLM feature MUST have an automated evaluation suite run against a **golden ground-truth dataset**: representative inputs with their known-good outputs, versioned in the repository alongside the code. |
-| AI-012 | Eval suites MUST NOT run on every push. They run **on demand**, and automatically on merge to a long-lived branch (`development`, `sandbox`, `staging`, `master`). This is a deliberate exception to [QUA-004](#qua--quality). |
+| AI-012 | Eval suites MUST NOT run on every push. They run **on demand**, and automatically on merge to a long-lived branch (`development`, `sandbox`, `staging`, `main`). This is a deliberate exception to [QUA-004](#qua--quality). |
 | AI-013 | The golden dataset is maintained as the system changes. New capabilities add cases, and **every regression found in production adds a case**. |
 | AI-014 | Eval results MUST be recorded and comparable across runs, so the effect of a change on answer quality is visible rather than asserted. |
 
@@ -195,14 +195,14 @@ Most of this domain is enforced by branch protection rather than by anyone remem
 | ID | Guideline |
 | --- | --- |
 | SCM-001 | All source code MUST be hosted on GitHub in the **BlueLabelLabs** organization. Client work MUST NOT live in personal accounts, other Git hosts, or local-only repositories. Where a client mandates their own organization or host, the Engineering Architect MAY approve it, recorded in the engagement constitution. |
-| SCM-002 | Every repository maintains four long-lived branches: **`development`** (top of stream, no environment), **`sandbox`**, **`staging`**, and **`master`**. `sandbox`, `staging`, and `master` correspond to the three environments. |
+| SCM-002 | Every repository maintains four long-lived branches: **`development`** (top of stream, no environment), **`sandbox`**, **`staging`**, and **`main`**. `sandbox`, `staging`, and `main` correspond to the three environments. |
 | SCM-003 | Nothing is pushed directly to a long-lived branch. **Every change arrives by pull request**, including a one-line fix, a promotion between branches, and work done by an agent. |
 | SCM-004 | Work branches are cut from `development` and named `<type>/BL###-<short-description>`, for example `feat/BL000-invite-flow` or `fix/BL000-token-refresh`. Branch names are lowercase. |
-| SCM-005 | Code flows **downstream**: `development` → `sandbox` → `staging` → `master`. Code moving the other way, back toward a feature branch, is moving **upstream**. |
-| SCM-006 | A hotfix branches from `master` and merges to `master` by pull request, then is **immediately pulled back upstream** to `staging`, `sandbox`, and `development`. A hotfix that is not pulled back upstream is a regression scheduled for the next release. |
+| SCM-005 | Code flows **downstream**: `development` → `sandbox` → `staging` → `main`. Code moving the other way, back toward a feature branch, is moving **upstream**. |
+| SCM-006 | A hotfix branches from `main` and merges to `main` by pull request, then is **immediately pulled back upstream** to `staging`, `sandbox`, and `development`. A hotfix that is not pulled back upstream is a regression scheduled for the next release. |
 | SCM-007 | Branch protection MUST be enabled on all four long-lived branches: pull request required, at least one approving review, required status checks passing, no force push, no branch deletion, and no self-approval. |
 | SCM-008 | A pull request is approved by someone other than its author. Nobody merges their own pull request, and neither does an agent. |
-| SCM-009 | Each environment is built and deployed by CI/CD **from its corresponding branch**: `sandbox` → development, `staging` → staging, `master` → production. `development` deploys nothing; it exists so a review session's worth of merged work promotes as one deployment rather than ten. |
+| SCM-009 | Each environment is built and deployed by CI/CD **from its corresponding branch**: `sandbox` → development, `staging` → staging, `main` → production. `development` deploys nothing; it exists so a review session's worth of merged work promotes as one deployment rather than ten. |
 | SCM-010 | A pull request title MUST be descriptive and MUST contain a link to its JIRA issue in bracket notation. The title becomes the commit message, so it is the thing someone reads in the log a year later. |
 | SCM-011 | Pull requests are **squashed on merge**, so one pull request becomes one commit. The exception is an **upstream pull**, which merges without squashing so the original commit hashes survive and can be matched against the branch they came from. |
 | SCM-012 | Do not rebase. Its genuine use cases are rare, and what is usually meant is a cross-branch pull. |

--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -57,6 +57,7 @@ Applies to everyone who directs an agent, product and engineering alike.
 | AGT-012 | Meaningful agent contribution MUST be disclosed in commits and pull requests. |
 | AGT-014 | MCP servers MUST be reviewed before being connected to an engagement. An MCP server is arbitrary code with access to your session. |
 | AGT-015 | Agent configuration (permissions, hooks, skills) MUST live in the repository, not on individual machines. |
+| AGT-016 | `AGENTS.md` and `CLAUDE.md` MUST be committed to the repository so the whole team gets the same agent behavior. Machine- or person-specific configuration goes in a gitignored `*.local.md` file that the committed file imports. |
 
 ## SEC — Security
 
@@ -78,6 +79,7 @@ Applies to everyone who directs an agent, product and engineering alike.
 | SEC-014 | Every endpoint uses TLS and requires authentication, independent of network topology. Health endpoints excepted. |
 | SEC-015 | We do not store passwords. Where an engagement leaves no alternative, hash with bcrypt using a unique per-password salt. |
 | SEC-016 | Access tokens and credentials MUST be stored in the platform's secure store, such as the OS keychain or keystore on a device. They MUST NOT be persisted in plain client storage (`UserDefaults`, `localStorage`, `sessionStorage`). |
+| SEC-017 | Never share your own credentials with another person, including a short-term or vendor developer. Give them their own access, or have them contribute code through someone who has it. |
 
 ## ARC — Architecture
 
@@ -154,7 +156,7 @@ Applies to everyone who directs an agent, product and engineering alike.
 | AI-009 | Experiments are reproducible and tracked: versioned notebooks, prompts, and datasets. |
 | AI-010 | An experimentation workstream has an explicit hypothesis, success criteria, and decision gate defined before it starts. |
 | AI-011 | Every LLM feature MUST have an automated evaluation suite run against a **golden ground-truth dataset**: representative inputs with their known-good outputs, versioned in the repository alongside the code. |
-| AI-012 | Eval suites MUST NOT run on every push. They run **on demand**, and automatically on merge to a long-lived branch (`develop`, `staging`, `main`). This is a deliberate exception to [QUA-004](#qua--quality). |
+| AI-012 | Eval suites MUST NOT run on every push. They run **on demand**, and automatically on merge to a long-lived branch (`development`, `sandbox`, `staging`, `master`). This is a deliberate exception to [QUA-004](#qua--quality). |
 | AI-013 | The golden dataset is maintained as the system changes. New capabilities add cases, and **every regression found in production adds a case**. |
 | AI-014 | Eval results MUST be recorded and comparable across runs, so the effect of a change on answer quality is visible rather than asserted. |
 
@@ -193,14 +195,19 @@ Most of this domain is enforced by branch protection rather than by anyone remem
 | ID | Guideline |
 | --- | --- |
 | SCM-001 | All source code MUST be hosted on GitHub in the **BlueLabelLabs** organization. Client work MUST NOT live in personal accounts, other Git hosts, or local-only repositories. Where a client mandates their own organization or host, the Engineering Architect MAY approve it, recorded in the engagement constitution. |
-| SCM-002 | Every repository maintains three long-lived branches corresponding to the three environments: **`main`** (production), **`staging`**, and **`develop`** (development). |
-| SCM-003 | Nothing is pushed directly to a long-lived branch. **Every change arrives by pull request**, including a one-line fix and including work by an agent. |
-| SCM-004 | Work branches are cut from `develop` and named `<type>/BL###-<short-description>`, for example `feat/BL000-invite-flow` or `fix/BL000-token-refresh`. |
-| SCM-005 | Code promotes **upward only**: `develop` → `staging` → `main`. A long-lived branch is never merged downward except as the back-merge required by SCM-006. |
-| SCM-006 | A hotfix branches from `main` and merges to `main` by pull request, then is **immediately back-merged** to `staging` and `develop`. A hotfix that is not back-merged is a regression scheduled for the next release. |
-| SCM-007 | Branch protection MUST be enabled on all three long-lived branches: pull request required, at least one approving review, required status checks passing, no force push, no branch deletion, and no self-approval. |
+| SCM-002 | Every repository maintains four long-lived branches: **`development`** (top of stream, no environment), **`sandbox`**, **`staging`**, and **`master`**. `sandbox`, `staging`, and `master` correspond to the three environments. |
+| SCM-003 | Nothing is pushed directly to a long-lived branch. **Every change arrives by pull request**, including a one-line fix, a promotion between branches, and work done by an agent. |
+| SCM-004 | Work branches are cut from `development` and named `<type>/BL###-<short-description>`, for example `feat/BL000-invite-flow` or `fix/BL000-token-refresh`. Branch names are lowercase. |
+| SCM-005 | Code flows **downstream**: `development` → `sandbox` → `staging` → `master`. Code moving the other way, back toward a feature branch, is moving **upstream**. |
+| SCM-006 | A hotfix branches from `master` and merges to `master` by pull request, then is **immediately pulled back upstream** to `staging`, `sandbox`, and `development`. A hotfix that is not pulled back upstream is a regression scheduled for the next release. |
+| SCM-007 | Branch protection MUST be enabled on all four long-lived branches: pull request required, at least one approving review, required status checks passing, no force push, no branch deletion, and no self-approval. |
 | SCM-008 | A pull request is approved by someone other than its author. Nobody merges their own pull request, and neither does an agent. |
-| SCM-009 | Each environment is built and deployed by CI/CD **from its corresponding branch**. A merge into `develop`, `staging`, or `main` is what deploys that environment. |
+| SCM-009 | Each environment is built and deployed by CI/CD **from its corresponding branch**: `sandbox` → development, `staging` → staging, `master` → production. `development` deploys nothing; it exists so a review session's worth of merged work promotes as one deployment rather than ten. |
+| SCM-010 | A pull request title MUST be descriptive and MUST contain a link to its JIRA issue in bracket notation. The title becomes the commit message, so it is the thing someone reads in the log a year later. |
+| SCM-011 | Pull requests are **squashed on merge**, so one pull request becomes one commit. The exception is an **upstream pull**, which merges without squashing so the original commit hashes survive and can be matched against the branch they came from. |
+| SCM-012 | Do not rebase. Its genuine use cases are rare, and what is usually meant is a cross-branch pull. |
+| SCM-013 | Every repository MUST have a `.gitignore` that excludes `.env` files, service-account JSON, `.pgpass`, and anything else carrying a credential. Seed it from [github/gitignore](https://github.com/github/gitignore). |
+| SCM-014 | Where a client has their own Git standards, theirs supersede these for that engagement. |
 
 ## QUA — Quality
 

--- a/guidelines/code-review.md
+++ b/guidelines/code-review.md
@@ -145,7 +145,7 @@ Most of this domain is enforced by branch protection, so it never reaches a revi
 | | |
 | --- | --- |
 | [SCM-004](README.md#scm--source-control) | Work branch cut from `development`, named `<type>/BL###-<description>`, lowercase |
-| [SCM-006](README.md#scm--source-control) | A hotfix merged to `master` is pulled back upstream. Skipping this is how a fixed bug comes back |
+| [SCM-006](README.md#scm--source-control) | A hotfix merged to `main` is pulled back upstream. Skipping this is how a fixed bug comes back |
 | [SCM-010](README.md#scm--source-control) | Pull request title is descriptive and carries its JIRA link |
 | [SCM-011](README.md#scm--source-control) | Squashed on merge, except promotions and upstream pulls, which preserve hashes |
 | [SCM-013](README.md#scm--source-control) | A `.gitignore` exists and excludes credential-bearing files |

--- a/guidelines/code-review.md
+++ b/guidelines/code-review.md
@@ -144,8 +144,12 @@ Most of this domain is enforced by branch protection, so it never reaches a revi
 
 | | |
 | --- | --- |
-| [SCM-004](README.md#scm--source-control) | Work branch cut from `develop` and named `<type>/BL###-<description>` |
-| [SCM-006](README.md#scm--source-control) | A hotfix merged to `main` is back-merged to `staging` and `develop`. Skipping this is how a fixed bug comes back |
+| [SCM-004](README.md#scm--source-control) | Work branch cut from `development`, named `<type>/BL###-<description>`, lowercase |
+| [SCM-006](README.md#scm--source-control) | A hotfix merged to `master` is pulled back upstream. Skipping this is how a fixed bug comes back |
+| [SCM-010](README.md#scm--source-control) | Pull request title is descriptive and carries its JIRA link |
+| [SCM-011](README.md#scm--source-control) | Squashed on merge, except promotions and upstream pulls, which preserve hashes |
+| [SCM-013](README.md#scm--source-control) | A `.gitignore` exists and excludes credential-bearing files |
+| [AGT-016](README.md#agt--working-with-agents) | `AGENTS.md`/`CLAUDE.md` committed; local config in a gitignored `*.local.md` |
 
 ### Tests
 

--- a/guidelines/source-control.md
+++ b/guidelines/source-control.md
@@ -1,39 +1,46 @@
 ---
 title: Source Control
 status: current
-version: 2.0
+version: 2.1
 owner: Bobby Gill
-last_reviewed: 2026-08-07
+last_reviewed: 2026-08-08
 ---
 
 # Source control
 
 The [SCM guidelines](README.md#scm--source-control) are the rules. This page is the model they describe, because a branching strategy is easier to show than to list.
 
-Almost all of this is enforced by branch protection rather than by anyone remembering it. Configure it once per repository and the guidelines hold themselves.
+Almost all of it is enforced by branch protection rather than by anyone remembering it. Configure that once per repository and most of these hold themselves.
 
-## Three branches, three environments
+## Four branches
 
-Every repository maintains three long-lived branches, one per environment ([SCM-002](README.md#scm--source-control)):
+```
+  feat/BL000-invite-flow ──► development ──► sandbox ──► staging ──► master
+                             (no env)          dev        staging      prod
+```
 
-| Branch | Environment | Resource identifier |
+| Branch | Deploys to | Identifier |
 | --- | --- | --- |
-| `main` | Production | `prod` |
+| `development` | nothing | — |
+| `sandbox` | Development | `dev` |
 | `staging` | Staging | `staging` |
-| `develop` | Development | `dev` |
+| `master` | Production | `prod` |
 
-The branch names and the resource identifiers deliberately differ. `main` is the universal convention for a default branch and `prod` is the universal convention in a resource name, and forcing either to match the other buys nothing.
+**`development` is the top of stream and the real source of truth** ([SCM-002](README.md#scm--source-control)). Every work branch is cut from it and every pull request merges back into it. It deploys nothing, and that is the point: a review session might merge ten pull requests, and on a large codebase ten deploys is an hour of transpiling for no benefit. Batch them and promote once.
 
-The environments themselves are separate AWS accounts or Azure resource groups ([OPS-008](README.md#ops--build-release-and-operations)). The branches say what code is where. The accounts keep the blast radius contained.
+Which makes `sandbox`, `staging`, and `master` doorways to their environments rather than places work happens.
 
-## Normal flow
+The branch names and the environment identifiers deliberately differ. `master` is the branch, `prod` is the string in a resource name, and `sandbox` is the branch whose environment is identified as `dev`. Forcing either side to match the other buys nothing and would break resource naming already in use.
 
-```
-  feat/BL000-invite-flow ──PR──► develop ──PR──► staging ──PR──► main
-                                    dev          staging         prod
-```
+## Downstream and upstream
 
-Cut a work branch from `develop`, named `<type>/BL###-<short-description>` ([SCM-004](README.md#scm--source-control)):
+Water flows down the stream. New code starts at the top and flows **downstream** to `master` and into production. Anything moving the other way, a hotfix heading back toward the feature branches, is moving **upstream** ([SCM-005](README.md#scm--source-control)).
+
+Worth saying plainly, because the intuition runs backwards for some people: promoting toward production is *down*, not up.
+
+## Getting work in
+
+Cut from `development`, named `<type>/BL###-<short-description>`, lowercase ([SCM-004](README.md#scm--source-control)):
 
 ```
 feat/BL000-invite-flow
@@ -41,44 +48,38 @@ fix/BL000-token-refresh
 chore/BL000-bump-deps
 ```
 
-Everything reaches a long-lived branch by pull request ([SCM-003](README.md#scm--source-control)). No exceptions for one-line changes, for urgency, or for work an agent produced. Promotion between environments is itself a pull request, which is what makes "what is in staging" answerable by looking rather than asking.
+Everything reaches a long-lived branch by pull request ([SCM-003](README.md#scm--source-control)). No exceptions for one-line changes, for urgency, or for work an agent produced.
 
-Code moves **upward only** ([SCM-005](README.md#scm--source-control)). Merging `main` back into `develop` outside the hotfix path means something reached production that was never in development, and you now have two branches that disagree about history.
+**The pull request title becomes the commit message.** Squash on merge means the title is what survives in the log, so it needs to be descriptive and carry its JIRA link in bracket notation ([SCM-010](README.md#scm--source-control), [SCM-011](README.md#scm--source-control)). The individual commits inside the pull request do not matter and will disappear, which is exactly right: over a day a developer writes `temp` and `wip` and `coffee`, and none of that belongs in history.
+
+## Promoting
+
+Promotion is also a pull request, from one long-lived branch to the next ([SCM-003](README.md#scm--source-control)). Branch protection would refuse a direct push anyway.
+
+**Merge a promotion with a merge commit, not a squash.** Squashing would rewrite the commits into a single new one, so the two branches drift apart in both hashes and count. Merging preserves them, and after a promotion both branches hold the same commits.
+
+That distinction matters more than it looks. When `sandbox` and `development` contain identical hashes, verifying a promotion carried what it was supposed to takes seconds. When they contain rewritten equivalents, it means reading two diffs side by side.
 
 ## Hotfixes
 
-The one case that runs the other way ([SCM-006](README.md#scm--source-control)):
+The one flow that runs upstream ([SCM-006](README.md#scm--source-control)):
 
 ```
-  main ──► hotfix/BL000-expired-token ──PR──► main
-                                               │
-                                     back-merge ▼
-                                        staging, develop
+  master ──► hotfix/BL000-expired-token ──PR──► master
+                                                  │
+                                    pull upstream  ▼
+                                   staging, sandbox, development
 ```
 
-Branch from `main`, merge to `main` by pull request, then **immediately back-merge to `staging` and `develop`**.
+Branch from `master`, merge to `master` by pull request, then **immediately pull it back upstream** through `staging`, `sandbox`, and `development`.
 
-The back-merge is the part that gets skipped, and skipping it is how a fixed bug returns. The fix exists only on `main`, the next promotion from `staging` carries the old code forward, and production regresses to the bug you already fixed. If you take one thing from this page, take this.
+The upstream pull is itself a pull request, so it gets reviewed, and it merges **without squashing** ([SCM-011](README.md#scm--source-control)) so the original hash survives. That is the whole trick: the same hash existing upstream is something a reviewer verifies at a glance, where a squashed equivalent has to be read and compared.
 
-## Each branch deploys its environment
-
-CI/CD builds and deploys each environment from its own branch ([SCM-009](README.md#scm--source-control)):
-
-| Merge into | Deploys to |
-| --- | --- |
-| `develop` | Development |
-| `staging` | Staging |
-| `main` | Production |
-
-A merge into a long-lived branch is the deployment trigger. There is no separate deploy step to remember, and no way to ship something that did not go through a pull request.
-
-Continuous integration and deployment are mandatory, and they run on GitHub Actions unless a client requires their own pipeline ([OPS-019](README.md#ops--build-release-and-operations), [OPS-020](README.md#ops--build-release-and-operations)). Nothing is built or deployed by hand from an engineer's machine.
-
-Because each environment builds from its own branch, **keeping the branches in step is what keeps the environments comparable**. That is the real reason SCM-005 and SCM-006 matter: a `staging` branch that has drifted from `develop`, or a hotfix that never came back down, means you are testing something other than what you are about to ship.
+**The upstream pull is the step that gets skipped, and skipping it is how a fixed bug comes back.** The fix exists only on `master`, the next promotion carries the old code forward over the top of it, and production regresses to the bug you already paid to fix. If you take one thing from this page, take this.
 
 ## Branch protection
 
-Enable this on `main`, `staging`, and `develop` ([SCM-007](README.md#scm--source-control)):
+Enable on `development`, `sandbox`, `staging`, and `master` ([SCM-007](README.md#scm--source-control)):
 
 - Require a pull request before merging
 - Require at least one approving review
@@ -88,12 +89,32 @@ Enable this on `main`, `staging`, and `develop` ([SCM-007](README.md#scm--source
 - No branch deletion
 - No self-approval
 
-This list is doing most of the work in this domain. "Always use pull requests" is a wish until direct pushes are refused by the server, and once they are, nobody has to remember the rule.
+This list does most of the work in this domain. "Always use pull requests" is a wish until direct pushes are refused by the server, and once they are, nobody has to remember the rule.
 
-A pull request is approved by someone other than its author, and nobody merges their own ([SCM-008](README.md#scm--source-control)). That applies to agents too, and it is one of the actions an agent never takes on its own ([AGT-010](README.md#agt--working-with-agents)).
+A pull request is approved by someone other than its author, and nobody merges their own ([SCM-008](README.md#scm--source-control)). That applies to agents, and it is one of the actions an agent never takes alone ([AGT-010](README.md#agt--working-with-agents)).
 
-## What this does not cover
+## What belongs in the repository
 
-Commit message format is not standardized, and this is not the document to invent one in.
+Every repository has a `.gitignore`, seeded from [github/gitignore](https://github.com/github/gitignore), excluding `.env` files, service-account JSON, `.pgpass`, and anything else carrying a credential ([SCM-013](README.md#scm--source-control)). No file containing an API key, credential, or secret is ever committed ([SEC-009](README.md#sec--security)).
 
-Releases are tagged on `main` using SemVer ([OPS-012](README.md#ops--build-release-and-operations)).
+**Adding a path to `.gitignore` does not untrack a file already committed.** This catches people. Commit the removal first, then the `.gitignore` change, then restore the file locally:
+
+```bash
+git rm --cached path/to/file
+# add the path to .gitignore
+git add .gitignore && git commit -m "Stop tracking path/to/file [BL000-123]"
+```
+
+If that file held a secret, removing it from the tip does not remove it from history. Rotate the credential; it is still readable in every clone.
+
+**Agent instruction files are committed.** `AGENTS.md` and `CLAUDE.md` belong in the repository so the team gets the same agent behavior rather than whatever each person configured ([AGT-015](README.md#agt--working-with-agents), [AGT-016](README.md#agt--working-with-agents)). Anything machine-specific or personal goes in a gitignored `*.local.md` that the committed file imports, so local setup never lands in a client's repository.
+
+## Two things not to do
+
+**Do not rebase** ([SCM-012](README.md#scm--source-control)). Its genuine use cases are rare, and what is usually meant is a cross-branch pull. The word gets used loosely and then somebody rewrites shared history.
+
+**Do not share your credentials with another person** ([SEC-017](README.md#sec--security)), including a vendor developer brought in for two days. Give them their own access and let them raise their own pull requests, or have them hand code to someone who already has access. Work merged under a name is that person's work, and they are accountable for having reviewed it.
+
+## Client standards win
+
+Where a client has their own Git standards, theirs supersede these for that engagement ([SCM-014](README.md#scm--source-control)). Record it in the engagement constitution so the deviation is visible rather than assumed.

--- a/guidelines/source-control.md
+++ b/guidelines/source-control.md
@@ -15,8 +15,8 @@ Almost all of it is enforced by branch protection rather than by anyone remember
 ## Four branches
 
 ```
-  feat/BL000-invite-flow ──► development ──► sandbox ──► staging ──► master
-                             (no env)          dev        staging      prod
+  feat/BL000-invite-flow ──► development ──► sandbox ──► staging ──► main
+                             (no env)          dev        staging     prod
 ```
 
 | Branch | Deploys to | Identifier |
@@ -24,17 +24,19 @@ Almost all of it is enforced by branch protection rather than by anyone remember
 | `development` | nothing | — |
 | `sandbox` | Development | `dev` |
 | `staging` | Staging | `staging` |
-| `master` | Production | `prod` |
+| `main` | Production | `prod` |
 
 **`development` is the top of stream and the real source of truth** ([SCM-002](README.md#scm--source-control)). Every work branch is cut from it and every pull request merges back into it. It deploys nothing, and that is the point: a review session might merge ten pull requests, and on a large codebase ten deploys is an hour of transpiling for no benefit. Batch them and promote once.
 
-Which makes `sandbox`, `staging`, and `master` doorways to their environments rather than places work happens.
+Which makes `sandbox`, `staging`, and `main` doorways to their environments rather than places work happens.
 
-The branch names and the environment identifiers deliberately differ. `master` is the branch, `prod` is the string in a resource name, and `sandbox` is the branch whose environment is identified as `dev`. Forcing either side to match the other buys nothing and would break resource naming already in use.
+The branch names and the environment identifiers deliberately differ. `main` is the branch, `prod` is the string in a resource name, and `sandbox` is the branch whose environment is identified as `dev`. Forcing either side to match the other buys nothing and would break resource naming already in use.
+
+**New repositories use `main`.** A repository already on `master` is not required to rename; the cost lands on every clone, every pipeline, and every protection rule, and it buys consistency rather than correctness. Rename when something else is already touching the pipeline.
 
 ## Downstream and upstream
 
-Water flows down the stream. New code starts at the top and flows **downstream** to `master` and into production. Anything moving the other way, a hotfix heading back toward the feature branches, is moving **upstream** ([SCM-005](README.md#scm--source-control)).
+Water flows down the stream. New code starts at the top and flows **downstream** to `main` and into production. Anything moving the other way, a hotfix heading back toward the feature branches, is moving **upstream** ([SCM-005](README.md#scm--source-control)).
 
 Worth saying plainly, because the intuition runs backwards for some people: promoting toward production is *down*, not up.
 
@@ -65,21 +67,21 @@ That distinction matters more than it looks. When `sandbox` and `development` co
 The one flow that runs upstream ([SCM-006](README.md#scm--source-control)):
 
 ```
-  master ──► hotfix/BL000-expired-token ──PR──► master
+  main ──► hotfix/BL000-expired-token ──PR──► main
                                                   │
                                     pull upstream  ▼
                                    staging, sandbox, development
 ```
 
-Branch from `master`, merge to `master` by pull request, then **immediately pull it back upstream** through `staging`, `sandbox`, and `development`.
+Branch from `main`, merge to `main` by pull request, then **immediately pull it back upstream** through `staging`, `sandbox`, and `development`.
 
 The upstream pull is itself a pull request, so it gets reviewed, and it merges **without squashing** ([SCM-011](README.md#scm--source-control)) so the original hash survives. That is the whole trick: the same hash existing upstream is something a reviewer verifies at a glance, where a squashed equivalent has to be read and compared.
 
-**The upstream pull is the step that gets skipped, and skipping it is how a fixed bug comes back.** The fix exists only on `master`, the next promotion carries the old code forward over the top of it, and production regresses to the bug you already paid to fix. If you take one thing from this page, take this.
+**The upstream pull is the step that gets skipped, and skipping it is how a fixed bug comes back.** The fix exists only on `main`, the next promotion carries the old code forward over the top of it, and production regresses to the bug you already paid to fix. If you take one thing from this page, take this.
 
 ## Branch protection
 
-Enable on `development`, `sandbox`, `staging`, and `master` ([SCM-007](README.md#scm--source-control)):
+Enable on `development`, `sandbox`, `staging`, and `main` ([SCM-007](README.md#scm--source-control)):
 
 - Require a pull request before merging
 - Require at least one approving review

--- a/guidelines/testing.md
+++ b/guidelines/testing.md
@@ -72,7 +72,7 @@ Evals are the test suite for the part of the system that fails quietly.
 **They do not run on every push** ([AI-012](README.md#ai--ai-and-agentic-systems)). This is a deliberate exception to [QUA-004](README.md#qua--quality), and the only one. A full eval suite costs real money in model calls and real minutes in wall clock, and running it on every commit to a feature branch buys nothing an engineer could not get by running it themselves. Instead:
 
 - **On demand**, so an engineer changing a prompt can measure the effect before opening a pull request. A `workflow_dispatch` GitHub Action is the usual mechanism.
-- **Automatically on merge to a long-lived branch**, `develop`, `staging`, and `main`, so nothing reaches an environment without having been measured.
+- **Automatically on merge to a long-lived branch**, so nothing reaches an environment without having been measured.
 
 That cadence puts the gate where it matters. Nothing reaches production without passing ([AI-003](README.md#ai--ai-and-agentic-systems)), and nobody waits twenty minutes to fix a typo.
 


### PR DESCRIPTION
Reading BlueLabel's 2023 Git standards document against the SCM domain found three places where I had invented an answer where an established one existed. Pairs with BlueLabelLabs/blueprint#21.

**151 guidelines**, up from 144.

## Three corrections

**Four branches, not three.** `development` is top of stream and deploys nothing, then `sandbox`, `staging`, `master`. I had collapsed `sandbox` and `development` into one branch on the assumption they were two words for the same thing. They are not: `development` exists so a review session's merges promote as a single deployment instead of one per pull request.

**Stream direction was backwards.** Code flows *downstream* toward production; a hotfix travels *upstream*. SCM-005 said "promotes upward only", which is the same direction and the opposite word. That is worse than being wrong, because both sides think they agree.

**Promotion stays a pull request**, against the document, because "always use pull requests" was a direct requirement and branch protection would refuse a direct push. The document's real concern was branches diverging, which is solved by merging promotions with a merge commit rather than a squash so the hashes stay identical.

## Recovered from the document

| | |
| --- | --- |
| SCM-010 | Pull request title is descriptive and carries a JIRA link. It becomes the commit message |
| SCM-011 | Squash on merge, except promotions and upstream pulls, which preserve hashes |
| SCM-012 | Do not rebase |
| SCM-013 | A `.gitignore` excluding `.env`, service-account JSON, and anything credential-bearing |
| SCM-014 | Client Git standards supersede ours for that engagement |
| SEC-017 | Never share your own credentials with another person, including short-term vendor developers |

## New

**AGT-016**: `AGENTS.md` and `CLAUDE.md` are committed, so the team gets the same agent behavior rather than whatever each person configured. Machine- or person-specific configuration goes in a gitignored `*.local.md` that the committed file imports, so local setup never lands in a client's repository.

## Retired from the document

The repository naming format `BLXXX - <ProductName> - React` does not match reality; actual repositories are lowercase and hyphenated, and OPS-003 already matches. The eleven-git-commands list is training material rather than a standard. "Stop using visual Git tools" is dropped. "Dev Lead" becomes Engineering Architect throughout.

## Verification

151 guidelines, 22 published files, every ID and anchor resolving, no internal token in published text. The golden path is deliberately unchanged: these are all invariants, and invariants render into the catalog rather than the golden path.

https://claude.ai/code/session_01GnmvTJD4nEP6GRJ1KbygmP