### PR TITLE
Add reference checking on pull requests

### DIFF
--- a/.github/scripts/check-references.mjs
+++ b/.github/scripts/check-references.mjs
@@ -1,0 +1,133 @@
+/**
+ * Check that this repository is internally consistent.
+ *
+ *   node .github/scripts/check-references.mjs [repo-root]
+ *
+ * Three things, all of which have broken here before:
+ *
+ *   1. every guideline ID referenced anywhere exists in the catalog
+ *   2. every link into the catalog lands on a heading that exists
+ *   3. every relative link points at a file that exists
+ *
+ * The first is the one that earns its keep. Retiring an ID leaves references
+ * that a file-based link checker cannot see, because the file it points at is
+ * still there. That has happened twice.
+ *
+ * Deliberately not here: the sanitization check that keeps internal references
+ * out of published text. That runs in the private methodology repo, before
+ * anything is written, because publishing the list of things we scan for would
+ * hand it to the people it guards against.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+const PREFIXES = ['AGT', 'SEC', 'ARC', 'API', 'DAT', 'AI', 'OPS', 'SCM', 'QUA', 'INT']
+const ID = `(?:${PREFIXES.join('|')})-\\d{3}`
+const ID_RE = new RegExp(`\\b(${ID})\\b`, 'g')
+const ROW_RE = new RegExp(`^\\| (${ID}) \\|`, 'gm')
+
+/** GitHub's heading slug. Punctuation is dropped, then each space becomes a hyphen. */
+const slug = (heading) =>
+  '#' +
+  heading
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/ /g, '-')
+
+/** What publishes is what git tracks. */
+function markdownFiles(repo) {
+  try {
+    const out = execFileSync('git', ['-C', repo, 'ls-files', '*.md', '**/*.md'], {
+      encoding: 'utf8',
+    })
+    const files = out.split('\n').filter(Boolean).map((f) => path.join(repo, f))
+    if (files.length) return files
+  } catch {
+    /* not a checkout; fall through */
+  }
+  const out = []
+  const walk = (dir) => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (['.git', 'images', 'node_modules'].includes(e.name)) continue
+      const p = path.join(dir, e.name)
+      if (e.isDirectory()) walk(p)
+      else if (e.name.endsWith('.md')) out.push(p)
+    }
+  }
+  walk(repo)
+  return out
+}
+
+function main() {
+  const repo = path.resolve(process.argv[2] ?? '.')
+  const catalogPath = path.join(repo, 'guidelines/README.md')
+  if (!fs.existsSync(catalogPath)) {
+    console.error(`No catalog at guidelines/README.md (looked under ${repo})`)
+    process.exit(1)
+  }
+
+  const catalog = fs.readFileSync(catalogPath, 'utf8')
+  const defined = new Set([...catalog.matchAll(ROW_RE)].map((m) => m[1]))
+  const anchors = new Set([...catalog.matchAll(/^## (.+)$/gm)].map((m) => slug(m[1])))
+
+  const problems = []
+  const files = markdownFiles(repo)
+
+  for (const file of files) {
+    const rel = path.relative(repo, file)
+    const text = fs.readFileSync(file, 'utf8')
+
+    for (const id of new Set([...text.matchAll(ID_RE)].map((m) => m[1]))) {
+      if (!defined.has(id)) {
+        problems.push(`${rel}: references ${id}, which is not in the catalog`)
+      }
+    }
+
+    for (const [, , link] of text.matchAll(/\[([^\]]*)\]\(([^)]+)\)/g)) {
+      if (/^(https?:|mailto:)/.test(link)) continue
+      const [target, hash] = link.split('#')
+
+      if (!target) {
+        // same-file anchor; only the catalog's own headings are known here
+        if (hash && file === catalogPath && !anchors.has('#' + hash)) {
+          problems.push(`${rel}: bad anchor -> #${hash}`)
+        }
+        continue
+      }
+
+      const resolved = path.resolve(path.dirname(file), target)
+      if (!fs.existsSync(resolved)) {
+        problems.push(`${rel}: broken link -> ${link}`)
+      } else if (hash && resolved === catalogPath && !anchors.has('#' + hash)) {
+        problems.push(`${rel}: bad catalog anchor -> #${hash}`)
+      }
+    }
+  }
+
+  const byDomain = {}
+  for (const id of defined) {
+    const d = id.split('-')[0]
+    byDomain[d] = (byDomain[d] ?? 0) + 1
+  }
+
+  console.log(`${defined.size} guidelines across ${Object.keys(byDomain).length} domains`)
+  console.log(
+    Object.entries(byDomain)
+      .sort((a, b) => b[1] - a[1])
+      .map(([d, n]) => `${d} ${n}`)
+      .join(' · ')
+  )
+  console.log(`${files.length} published markdown files checked`)
+
+  if (problems.length) {
+    console.error(`\n${problems.length} problem${problems.length === 1 ? '' : 's'}:\n`)
+    for (const p of problems) console.error(`  ${p}`)
+    process.exit(1)
+  }
+  console.log('\nNo problems.')
+}
+
+main()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,33 @@
+name: Check
+
+# Guidelines are cited by ID in reviews and exception records, so a reference
+# that no longer resolves is a broken promise rather than a typo. This runs on
+# every pull request, including the ones the sync workflow opens.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  references:
+    name: References
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node builtins only; there is nothing to install.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Check guideline IDs, anchors, and links
+        run: node .github/scripts/check-references.mjs .


### PR DESCRIPTION
Closes the status-check half of [SCM-007](https://github.com/BlueLabelLabs/BLL-Engineering-Standards/blob/main/guidelines/README.md#scm--source-control). Branch protection now requires a pull request and a review, but there was no check to require, because this repository had no CI at all.

## The gap

Blueprint's validator runs before the sync workflow opens its pull request, so generated content is covered. **Anything hand-written was not.** Both bugs of that kind in recent memory were mine: a dangling `OPS-001` reference left behind when the ID was retired, and a new file the validator could not see because it was not staged yet.

## What it checks

| | |
| --- | --- |
| Guideline IDs | Every ID referenced anywhere exists in the catalog |
| Anchors | Every link into the catalog lands on a heading that exists |
| Links | Every relative link points at a file that exists |

The ID check is the one that earns its keep. Retiring an ID leaves references that a file-based link checker cannot see, because the file it points at is still there.

## What it deliberately does not check

**Sanitization.** The check that keeps project codes, internal repository names, and addresses out of published text stays in the private methodology repo and runs *before* anything is written. Publishing the list of tokens we scan for would hand it to the people it guards against.

That is the split rather than a duplication: the public repository checks its own internal consistency, the private one checks what must not leak.

## Verification

Clean run passes at 151 guidelines across 22 published files. Negative-tested against all three failure modes:

```
references API-997, which is not in the catalog
bad catalog anchor -> #sec--securrity
broken link -> tooling.md
```

Node builtins only, no dependencies, nothing to install.

## After this merges

Add `References` to the required status checks in branch protection, which I cannot do until the check has run at least once on `main`.

There is also an overlap worth removing later: blueprint's validator implements the same ID, anchor, and link logic. Once this exists, that workflow can call this script from the checkout it already makes, so there is one implementation with two callers rather than two that can drift.

https://claude.ai/code/session_01GnmvTJD4nEP6GRJ1KbygmP